### PR TITLE
[T31] add imagePickerBottomSheet

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,4 +79,15 @@ dependencies {
     implementation 'com.google.android.libraries.places:places:3.1.0'
 
     implementation 'com.guolindev.permissionx:permissionx:1.7.1'
+
+    // camera
+    implementation 'androidx.camera:camera-view:1.3.0-alpha06'
+
+    // activity
+    implementation 'androidx.activity:activity-ktx:1.7.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.7'
+
+    //contact retriever
+    implementation 'com.github.vestrel00:contacts-android:0.2.4'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
     <application
         android:name="com.gathering.android.Application"
         android:allowBackup="true"

--- a/app/src/main/java/com/gathering/android/event/myevent/MyEventFragment.kt
+++ b/app/src/main/java/com/gathering/android/event/myevent/MyEventFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.gathering.android.R
 import com.gathering.android.databinding.FrgMyEventBinding
+import com.gathering.android.event.home.model.Event
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/app/src/main/java/com/gathering/android/event/myevent/addevent/AddEventBottomSheetFragment.kt
+++ b/app/src/main/java/com/gathering/android/event/myevent/addevent/AddEventBottomSheetFragment.kt
@@ -1,6 +1,7 @@
 package com.gathering.android.event.myevent.addevent
 
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,6 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 import javax.inject.Inject
 
+
 @AndroidEntryPoint
 class AddEventBottomSheetFragment : BottomSheetDialogFragment() {
 
@@ -32,8 +34,15 @@ class AddEventBottomSheetFragment : BottomSheetDialogFragment() {
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = BottomSheetAddEventBinding.inflate(LayoutInflater.from(requireContext()))
+
+        val selectedImagePath = arguments?.getString(KEY_ARGUMENT_SELECTED_IMAGE)
+
+
+        if(selectedImagePath != null) {
+            binding.imgEvent.setImageURI(Uri.parse(selectedImagePath))
+        }
 
         viewModel.viewState.observe(viewLifecycleOwner) { state ->
             when (state) {
@@ -74,6 +83,9 @@ class AddEventBottomSheetFragment : BottomSheetDialogFragment() {
         }
 
         binding.btnAddEvent.setOnClickListener {
+            //TODO:
+            //1- upload the image
+            //2- save the image url
             viewModel.onAddEventButtonClicked(provideEvent())
         }
 
@@ -105,5 +117,9 @@ class AddEventBottomSheetFragment : BottomSheetDialogFragment() {
             isMyEvent = true,
             activities = listOf("party", "dinner", "drink", "cake", "tea")
         )
+    }
+
+    companion object {
+        const val KEY_ARGUMENT_SELECTED_IMAGE = "selectedImagePath"
     }
 }

--- a/app/src/main/java/com/gathering/android/event/myevent/addevent/pic/AddPicBottomSheet.kt
+++ b/app/src/main/java/com/gathering/android/event/myevent/addevent/pic/AddPicBottomSheet.kt
@@ -1,29 +1,172 @@
 package com.gathering.android.event.myevent.addevent.pic
 
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
+import androidx.navigation.fragment.findNavController
 import com.gathering.android.R
 import com.gathering.android.databinding.BottomSheetAddPicBinding
+import com.gathering.android.event.myevent.addevent.AddEventBottomSheetFragment.Companion.KEY_ARGUMENT_SELECTED_IMAGE
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import java.io.ByteArrayOutputStream
 
 class AddPicBottomSheet : BottomSheetDialogFragment() {
 
     private lateinit var binding: BottomSheetAddPicBinding
-
+    private val GALLERY_REQUEST_CODE = 1001
+    private val CAMERA_REQUEST_CODE = 1002
+    private val GALLERY_PERMISSION_CODE = 1003
+    private val CAMERA_PERMISSION_CODE = 1004
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(DialogFragment.STYLE_NORMAL, R.style.CustomBottomSheetDialogTheme)
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
         binding = BottomSheetAddPicBinding.inflate(LayoutInflater.from(requireContext()))
+
+        binding.rotateLeft.setOnClickListener {
+            rotateImageViewBitmap(-90f)
+        }
+
+        binding.rotateRight.setOnClickListener {
+            rotateImageViewBitmap(90f)
+        }
+        binding.btnCamera.setOnClickListener {
+            if (allPermissionsGranted(REQUIRED_CAMERA_PERMISSIONS)) {
+                openCamera()
+            } else {
+                requestPermissions(
+                    REQUIRED_CAMERA_PERMISSIONS, CAMERA_PERMISSION_CODE
+                )
+            }
+        }
+
+        binding.btnGallery.setOnClickListener {
+            if (allPermissionsGranted(REQUIRED_GALLERY_PERMISSIONS)) {
+                openGallery()
+            } else {
+                requestPermissions(
+                    REQUIRED_GALLERY_PERMISSIONS, GALLERY_PERMISSION_CODE
+                )
+            }
+        }
+
+        binding.btnOk.setOnClickListener {
+            uriString = getImagePath((binding.imageView.drawable as BitmapDrawable).bitmap)
+
+            val bundle = bundleOf(KEY_ARGUMENT_SELECTED_IMAGE to uriString)
+
+            findNavController().navigate(R.id.action_back_to_add_event, bundle)
+        }
+
         return binding.root
     }
+
+    private fun rotateImageViewBitmap(degree: Float) {
+        val bitmap = (binding.imageView.drawable as BitmapDrawable).bitmap
+        val matrix = Matrix()
+        matrix.postRotate(degree)
+        val rotatedBitmap = Bitmap.createBitmap(
+            bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
+        )
+        binding.imageView.setImageBitmap(rotatedBitmap)
+    }
+
+    private fun openCamera() {
+        val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        startActivityForResult(takePictureIntent, CAMERA_REQUEST_CODE)
+    }
+
+    private fun allPermissionsGranted(permList: Array<String>) = permList.all {
+        requireContext().checkSelfPermission(
+            it
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private var uriString: String? = null
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == GALLERY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            data?.data?.let { uri ->
+                binding.imageView.setImageURI(uri)
+                uriString = uri.toString()
+            }
+        } else if (requestCode == CAMERA_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            val imageBitmap = data?.extras?.get("data") as Bitmap
+
+            binding.imageView.setImageBitmap(imageBitmap)
+        } else {
+            Toast.makeText(requireContext(), "operation cancelled by user", Toast.LENGTH_LONG)
+                .show()
+        }
+    }
+
+    private fun getImagePath(inImage: Bitmap): String {
+        val bytes = ByteArrayOutputStream()
+        inImage.compress(Bitmap.CompressFormat.JPEG, 100, bytes)
+
+        val path = MediaStore.Images.Media.insertImage(
+            requireContext().contentResolver, inImage, "gathering_" + System.currentTimeMillis(), null
+        )
+        return Uri.parse(path).toString()
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>, grantResults: IntArray
+    ) {
+        if (requestCode == CAMERA_PERMISSION_CODE) {
+            if (allPermissionsGranted(REQUIRED_CAMERA_PERMISSIONS)) {
+                openCamera()
+            } else {
+                Toast.makeText(requireContext(), "camera permission denied", Toast.LENGTH_LONG)
+                    .show()
+            }
+        } else if (requestCode == GALLERY_PERMISSION_CODE) {
+            if (allPermissionsGranted(REQUIRED_GALLERY_PERMISSIONS)) {
+                openGallery()
+            } else {
+                Toast.makeText(requireContext(), "gallery permission denied", Toast.LENGTH_LONG)
+                    .show()
+            }
+        }
+    }
+
+    private fun openGallery() {
+        val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+        startActivityForResult(intent, GALLERY_REQUEST_CODE)
+    }
+
+    companion object {
+        private val REQUIRED_CAMERA_PERMISSIONS = mutableListOf(
+            Manifest.permission.CAMERA
+        ).apply {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            }
+        }.toTypedArray()
+
+        private val REQUIRED_GALLERY_PERMISSIONS = mutableListOf<String>().apply {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            }
+        }.toTypedArray()
+    }
 }
+
+

--- a/app/src/main/java/com/gathering/android/navhost/NavHostActivity.kt
+++ b/app/src/main/java/com/gathering/android/navhost/NavHostActivity.kt
@@ -28,8 +28,7 @@ class NavHostActivity : AppCompatActivity() {
 
         viewModel.viewState.observe(this) { state ->
             when (state) {
-                NavHostViewState.NavigateToIntroScreen ->
-                    findNavController().navigate(R.id.action_homeFragment_to_introFragment)
+                NavHostViewState.NavigateToIntroScreen -> findNavController().navigate(R.id.action_homeFragment_to_introFragment)
             }
         }
     }

--- a/app/src/main/res/layout/bottom_sheet_add_event.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_event.xml
@@ -10,8 +10,9 @@
 
         <ImageButton
             android:id="@+id/img_event"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
+            android:scaleType="fitXY"
             android:layout_marginStart="@dimen/img_view_margin_start"
             android:layout_marginTop="@dimen/img_view_margin_top"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/bottom_sheet_add_pic.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_pic.xml
@@ -1,24 +1,74 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/padding">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ImageView
+        android:id="@+id/imageView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="@dimen/btn_sheet_imageView"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_launcher_foreground"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/textView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/take_pick_pic"
-            android:textSize="@dimen/tv_text_size_medium"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <Button
+        android:id="@+id/rotate_left"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/rotate_left"
+        app:layout_constraintBottom_toBottomOf="@+id/imageView"
+        app:layout_constraintStart_toStartOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+    <Button
+        android:id="@+id/rotate_right"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/rotate_right"
+        app:layout_constraintBottom_toBottomOf="@+id/imageView"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:layout_constraintTop_toBottomOf="@+id/imageView" />
+
+    <Button
+        android:id="@+id/btn_camera"
+        style="@style/buttonStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:background="@drawable/custom_button"
+        android:text="@string/open_camera"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/imageView" />
+
+    <Button
+        android:id="@+id/btn_gallery"
+        style="@style/buttonStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:background="@drawable/custom_button"
+        android:text="@string/open_gallery"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/imageView" />
+
+    <Button
+        android:id="@+id/btn_ok"
+        style="@style/buttonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/custom_button"
+        android:text="@string/ok"
+        app:layout_constraintTop_toBottomOf="@id/btn_camera" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -99,7 +99,11 @@
         android:id="@+id/addPicBottomSheet"
         android:name="com.gathering.android.event.myevent.addevent.pic.AddPicBottomSheet"
         android:label="AddPicBottomSheet"
-        tools:layout="@layout/bottom_sheet_add_pic" />
+        tools:layout="@layout/bottom_sheet_add_pic">
+        <action
+            android:id="@+id/action_back_to_add_event"
+            app:destination="@id/addEventBottomSheetFragment" />
+    </dialog>
     <dialog
         android:id="@+id/inviteFriendBottomSheet"
         android:name="com.gathering.android.event.myevent.addevent.invitation.InviteFriendBottomSheet"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -51,4 +51,8 @@
     <dimen name="img_view_margin_start">16dp</dimen>
     <dimen name="img_view_margin_top">16dp</dimen>
     <dimen name="img_height">256dp</dimen>
+
+    <dimen name="btn_sheet_imageView">256dp</dimen>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,10 @@
     <string name="invite_friends">Invite Friend</string>
     <string name="ok">ok</string>
     <string name="you_are_here">You are here</string>
+    <string name="open_gallery">open gallery</string>
+    <string name="open_camera">open camera</string>
+    <string name="rotate_right">rotate right</string>
+    <string name="rotate_left">rotate left</string>
+    <string name="contact">contact</string>
+    <string name="delete">delete</string>
 </resources>


### PR DESCRIPTION
**add addPicBottomSheet** 

- user should be able to click on the open camera button and take a picture, and by clicking ok should navigate back to add event bottom sheet and imageView should be set to the captured photo.

- user should be able to click on open gallery, pick a photo, click ok and navigate back to add event, and have the imageView set to the chosen photo from the gallery. 


### this is why I chose to use intents instead of cameraX:

1. I needed basic camera functionality 
2. cameraX provides support for advanced features like HDR, portrait mode, and night mode but we don't need them