### PR TITLE
[T113] migrate signInScreen to compose with featureFlag

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ android {
 
 dependencies {
 
+    implementation 'com.google.android.gms:play-services-wallet:19.2.1'
     def composeBom = platform('androidx.compose:compose-bom:2023.09.02')
     implementation composeBom
     androidTestImplementation composeBom
@@ -110,4 +111,6 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-tooling'
     implementation 'androidx.activity:activity-compose:1.8.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
+    implementation "androidx.compose.material:material-icons-extended:1.5.3"
+    implementation "androidx.compose.material:material:1.0.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,5 +112,4 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.8.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
     implementation "androidx.compose.material:material-icons-extended:1.5.3"
-    implementation "androidx.compose.material:material:1.0.0"
 }

--- a/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
@@ -31,9 +31,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.gathering.android.R
 import com.gathering.android.common.CustomButton
-import com.gathering.android.common.EmailTextField
-import com.gathering.android.common.PasswordTextField
-import com.gathering.android.common.UnderlinedButton
+import com.gathering.android.common.GatheringEmailTextField
+import com.gathering.android.common.GatheringPasswordTextField
+import com.gathering.android.common.CustomUnderlinedButton
 import com.gathering.android.common.isComposeEnabled
 import com.gathering.android.common.showErrorText
 import com.gathering.android.databinding.ScreenSignInBinding
@@ -156,13 +156,13 @@ class SignInScreen : DialogFragment(), SignInNavigator {
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                EmailTextField(
+                GatheringEmailTextField(
                     value = email,
                     onValueChange = { email = it },
                     label = "Email"
                 )
 
-                PasswordTextField(
+                GatheringPasswordTextField(
                     value = password,
                     onValueChange = { password = it },
                     label = "Password"
@@ -173,7 +173,7 @@ class SignInScreen : DialogFragment(), SignInNavigator {
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Start,
                 ) {
-                    UnderlinedButton(text = "forgot password?",
+                    CustomUnderlinedButton(text = "forgot password?",
                         onClick = {
                         viewModel.onForgotPassTvClicked()
                     })

--- a/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -133,7 +136,7 @@ class SignInScreen : DialogFragment(), SignInNavigator {
         )
     }
 
-    @Preview(showBackground = true, device = "id:pixel_7")
+    @Preview(showBackground = true, device = "spec:parent=pixel_7")
     @Composable
     fun SignInScreenPreview() {
         LogInScreen(true, "user does not exist!!")
@@ -149,6 +152,7 @@ class SignInScreen : DialogFragment(), SignInNavigator {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
                     .padding(10.dp),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/gathering/android/auth/signin/SignInScreen.kt
@@ -4,12 +4,38 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.gathering.android.R
+import com.gathering.android.common.CustomButton
+import com.gathering.android.common.EmailTextField
+import com.gathering.android.common.PasswordTextField
+import com.gathering.android.common.UnderlinedButton
+import com.gathering.android.common.isComposeEnabled
 import com.gathering.android.common.showErrorText
 import com.gathering.android.databinding.ScreenSignInBinding
+import com.gathering.android.ui.theme.GatheringTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -33,37 +59,60 @@ class SignInScreen : DialogFragment(), SignInNavigator {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        binding = ScreenSignInBinding.inflate(layoutInflater)
-        return binding.root
+        return if (!isComposeEnabled) {
+            binding = ScreenSignInBinding.inflate(layoutInflater)
+            binding.root
+        } else {
+            ComposeView(requireContext()).apply {
+                setContent {
+                    GatheringTheme {
+                        Surface(
+                            modifier = Modifier.fillMaxSize(),
+                            color = MaterialTheme.colorScheme.background
+                        ) {
+                            val state = viewModel.uiState.collectAsState()
+                            LogInScreen(state.value.isInProgress, state.value.errorMessage)
+                        }
+
+                    }
+                }
+            }
+        }
     }
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.btnSignIn.setOnClickListener {
-            val email = binding.etMail.text.toString()
-            val pass = binding.etPass.text.toString()
-            viewModel.onSignInButtonClicked(email, pass)
-        }
+        if (isComposeEnabled) {
+            viewModel.onViewCreated(this)
+            return
+        } else {
+            binding.btnSignIn.setOnClickListener {
+                val email = binding.etMail.text.toString()
+                val pass = binding.etPass.text.toString()
+                viewModel.onSignInButtonClicked(email, pass)
+            }
 
-        binding.tvForgetPassword.setOnClickListener {
-            viewModel.onForgotPassTvClicked()
-        }
+            binding.tvForgetPassword.setOnClickListener {
+                viewModel.onForgotPassTvClicked()
+            }
 
 
-        lifecycleScope.launch {
-            viewModel.uiState.collectLatest { state ->
-                if (state.isInProgress) {
-                    binding.btnSignIn.startAnimation()
-                } else {
-                    binding.btnSignIn.revertAnimation()
-                }
-                state.errorMessage?.let {
-                    showErrorText(it)
+            lifecycleScope.launch {
+                viewModel.uiState.collectLatest { state ->
+                    if (state.isInProgress) {
+                        binding.btnSignIn.startAnimation()
+                    } else {
+                        binding.btnSignIn.revertAnimation()
+                    }
+                    state.errorMessage?.let {
+                        showErrorText(it)
+                    }
                 }
             }
+            viewModel.onViewCreated(this)
         }
-        viewModel.onViewCreated(this)
     }
 
     override fun navigateToHome() {
@@ -83,4 +132,59 @@ class SignInScreen : DialogFragment(), SignInNavigator {
             R.id.action_signInScreen_to_forgetPasswordScreen
         )
     }
+
+    @Preview(showBackground = true, device = "id:pixel_7")
+    @Composable
+    fun SignInScreenPreview() {
+        LogInScreen(true, "user does not exist!!")
+    }
+
+    @Composable
+    private fun LogInScreen(isInProgress: Boolean, error: String? = null) {
+        var email by rememberSaveable { mutableStateOf("") }
+        var password by rememberSaveable { mutableStateOf("") }
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(10.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                EmailTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = "Email"
+                )
+
+                PasswordTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = "Password"
+                )
+
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start,
+                ) {
+                    UnderlinedButton(text = "forgot password?",
+                        onClick = {
+                        viewModel.onForgotPassTvClicked()
+                    })
+                }
+
+                CustomButton(
+                    text = "SIGN IN",
+                    onClick = { viewModel.onSignInButtonClicked(email, password) },
+                    isLoading = isInProgress,
+                    error = error
+                )
+
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/gathering/android/common/Composables.kt
+++ b/app/src/main/java/com/gathering/android/common/Composables.kt
@@ -1,0 +1,156 @@
+package com.gathering.android.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmailTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    TextField(
+        shape = RoundedCornerShape(5.dp),
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        singleLine = true,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { }
+            .padding(10.dp),
+        colors = TextFieldDefaults
+            .textFieldColors(containerColor = Color.Transparent),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PasswordTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+
+    ) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    TextField(modifier = Modifier
+        .fillMaxWidth()
+        .clickable { }
+        .padding(10.dp),
+        value = value,
+        onValueChange = { newValue ->
+            onValueChange(newValue)
+        },
+        label = { Text(label) },
+        singleLine = true,
+        trailingIcon = {
+            val image = if (passwordVisible) Icons.Filled.Visibility
+            else Icons.Filled.VisibilityOff
+
+            val description = if (passwordVisible) "Hide password" else "Show password"
+
+            IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                Icon(imageVector = image, contentDescription = description)
+            }
+        },
+        visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        colors = TextFieldDefaults.textFieldColors(containerColor = Color.Transparent)
+    )
+}
+
+
+@Composable
+fun CustomButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    error: String? = null
+) {
+    Button(
+        shape = RoundedCornerShape(0.dp),
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth(2f)
+            .padding(top = 30.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.DarkGray
+        )
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(color = Color.White)
+        } else {
+            Text(text)
+        }
+    }
+
+    if (error != null) {
+        Text(
+            text = error,
+            color = Color.Red
+        )
+    }
+}
+
+@Composable
+fun UnderlinedButton(text: String, onClick: () -> Unit) {
+    val underlinedText = remember(text) {
+        AnnotatedString.Builder(text).apply {
+            addStyle(
+                style = SpanStyle(textDecoration = TextDecoration.Underline),
+                start = 0,
+                end = text.length
+            )
+        }.toAnnotatedString()
+    }
+
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = Color.Black,
+        )
+    ) {
+        Text(
+            text = underlinedText
+        )
+    }
+}
+
+
+

--- a/app/src/main/java/com/gathering/android/common/Composables.kt
+++ b/app/src/main/java/com/gathering/android/common/Composables.kt
@@ -30,12 +30,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EmailTextField(
+fun GatheringEmailTextField(
     value: String,
     onValueChange: (String) -> Unit,
     label: String,
@@ -59,7 +58,7 @@ fun EmailTextField(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PasswordTextField(
+fun GatheringPasswordTextField(
     value: String,
     onValueChange: (String) -> Unit,
     label: String,
@@ -128,7 +127,7 @@ fun CustomButton(
 }
 
 @Composable
-fun UnderlinedButton(text: String, onClick: () -> Unit) {
+fun CustomUnderlinedButton(text: String, onClick: () -> Unit) {
     val underlinedText = remember(text) {
         AnnotatedString.Builder(text).apply {
             addStyle(

--- a/app/src/main/java/com/gathering/android/common/FeatureFlags.kt
+++ b/app/src/main/java/com/gathering/android/common/FeatureFlags.kt
@@ -1,0 +1,3 @@
+package com.gathering.android.common
+
+const val isComposeEnabled = true

--- a/app/src/main/java/com/gathering/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/gathering/android/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package com.gathering.android.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)
+val Yellow = Color(0xFFF4CE14)
+val Peach = Color(0xFFFFC8AF)
+

--- a/app/src/main/java/com/gathering/android/ui/theme/Theme.kt
+++ b/app/src/main/java/com/gathering/android/ui/theme/Theme.kt
@@ -1,0 +1,48 @@
+package com.gathering.android.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color.Companion.Yellow
+import androidx.compose.ui.platform.LocalContext
+
+
+private val darkColorScheme = darkColorScheme(
+    primary = Yellow,
+    secondary = Yellow,
+    tertiary = Yellow
+)
+
+private val lightColorScheme = lightColorScheme(
+    primary = PurpleGrey40,
+    secondary = PurpleGrey40,
+    tertiary = PurpleGrey40
+)
+
+@Composable
+fun GatheringTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+
+        darkTheme -> darkColorScheme
+        else -> lightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/gathering/android/ui/theme/Type.kt
+++ b/app/src/main/java/com/gathering/android/ui/theme/Type.kt
@@ -1,0 +1,33 @@
+package com.gathering.android.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+    /* Other default text styles to override
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    */
+)

--- a/app/src/main/res/layout/screen_sign_in.xml
+++ b/app/src/main/res/layout/screen_sign_in.xml
@@ -17,7 +17,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/guideline_start"
             app:startIconDrawable="@drawable/ic_person">
-
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/et_mail"
                 android:layout_width="match_parent"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,23 +1,18 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
+#Wed Oct 11 12:29:35 EDT 2023
+android.enableJetifier=true
 android.nonTransitiveRClass=true
+android.useAndroidX=true
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding\=UTF-8


### PR DESCRIPTION
- Added material dependency to build.gradle
- added featureFlag for migration 
- added composable functions to composables.kt in common folder (so we can use same button/textfields multiple times for multiple pages)
- created ui.theme folder that contains : type.kt, color.kt, theme.kt for gathering 
- handled view in darkmode in theme.kt


<img width="1016" alt="Screen Shot 2023-10-11 at 3 41 53 PM" src="https://github.com/moyarsuccess/gathering/assets/111448666/6cc94af2-b2ad-48b9-a9e9-bbe13e7c2783">
